### PR TITLE
[Fix] Fix minute & hour increment bug

### DIFF
--- a/Digital_Timer/README.md
+++ b/Digital_Timer/README.md
@@ -45,17 +45,19 @@
 <li> Refer to 7-Segment Decoder Truth Table snapshot in reference directory </li>
 
 ## Status:
+- 20240828 - Fix minutes & hours increment unexpectedly issue
 - 20240828 - Add timer_pause, timer_clear & timer_reset into TB and fix timer_pause & timer_clear bugs
 - 20240828 - Fix bugs and resolve compile issue
 - 20240828 - Init DB
 
 ## Changelist:
+- 20240828 - Fix minutes & hours increment issue
 - 20240828 - Fix timer_pause not working as intended issue
 - 20240828 - Fix timer_clear not working as intended issue
 - 20240828 - Fix TB & RTL for compile & function
 
 ## To-Do:
-- Fix design to increment minutes and hours correctly
+- (Resolved) Fix design to increment minutes and hours correctly
 - (Resolved) timer_clear not working properly -- timer_clk not reset to low if already high
 - (Resolved) timer_pause not working properly -- timer_clk still toggling during timer_pause assertion
   - Edge-case where timer_clk_count == 'd9, cause digital_clock_in to continue toggling

--- a/Digital_Timer/digit_iter.sv
+++ b/Digital_Timer/digit_iter.sv
@@ -8,7 +8,7 @@ module digit_iter #(
     input timer_clk,
     input int_reset_b,
 
-    input prev_overflow_ind,
+    input [4:0] prev_overflow_ind,
 
     input [6:0] clock_digit_in,
 
@@ -16,6 +16,7 @@ module digit_iter #(
 
     output reg overflow_ind
 );
+    wire prev_overflow_ind_merge = & prev_overflow_ind;
 
     always @(posedge timer_clk or negedge int_reset_b) begin
         if (~int_reset_b) begin
@@ -47,7 +48,7 @@ module digit_iter #(
         if (~int_reset_b) begin
             clock_digit_out <= 7'b0000001; // 0
         end else begin
-            if (prev_overflow_ind) begin
+            if (prev_overflow_ind_merge) begin
                 case(clock_digit_in)
                     7'b0000001: clock_digit_out <= 7'b1001111; // 0 -> 1
                     7'b1001111: clock_digit_out <= 7'b0010010; // 1 -> 2

--- a/Digital_Timer/digital_timer.sv
+++ b/Digital_Timer/digital_timer.sv
@@ -71,7 +71,7 @@ module digital_timer #() (
                         .int_reset_b       (int_reset_b),
                         .clock_digit_in    (digital_clock_in[iter]),
                         .clock_digit_out   (digital_clock_out[iter]),
-                        .prev_overflow_ind (1'b1),
+                        .prev_overflow_ind (5'b11111),
                         .overflow_ind      (sec_digit_overflow[0])
                     );
                 1: digit_iter #(
@@ -85,7 +85,7 @@ module digital_timer #() (
                         .int_reset_b       (int_reset_b),
                         .clock_digit_in    (digital_clock_in[iter]),
                         .clock_digit_out   (digital_clock_out[iter]),
-                        .prev_overflow_ind (sec_digit_overflow[0]),
+                        .prev_overflow_ind ({sec_digit_overflow[0], 4'b1111}),
                         .overflow_ind      (sec_digit_overflow[1])
                     );
                 2: digit_iter #(
@@ -99,7 +99,7 @@ module digital_timer #() (
                         .int_reset_b       (int_reset_b),
                         .clock_digit_in    (digital_clock_in[iter]),
                         .clock_digit_out   (digital_clock_out[iter]),
-                        .prev_overflow_ind (sec_digit_overflow[1]),
+                        .prev_overflow_ind ({sec_digit_overflow, 3'b111}),
                         .overflow_ind      (min_digit_overflow[0])
                     );
                 3: digit_iter #(
@@ -113,7 +113,7 @@ module digital_timer #() (
                         .int_reset_b       (int_reset_b),
                         .clock_digit_in    (digital_clock_in[iter]),
                         .clock_digit_out   (digital_clock_out[iter]),
-                        .prev_overflow_ind (min_digit_overflow[0]),
+                        .prev_overflow_ind ({min_digit_overflow[0], sec_digit_overflow, 2'b11}),
                         .overflow_ind      (min_digit_overflow[1])
                     );
                 4: digit_iter #(
@@ -127,7 +127,7 @@ module digital_timer #() (
                         .int_reset_b       (int_reset_b),
                         .clock_digit_in    (digital_clock_in[iter]),
                         .clock_digit_out   (digital_clock_out[iter]),
-                        .prev_overflow_ind (min_digit_overflow[1]),
+                        .prev_overflow_ind ({min_digit_overflow, sec_digit_overflow, 1'b1}),
                         .overflow_ind      (hour_digit_overflow[0])
                     );
                 5: digit_iter #(
@@ -141,7 +141,7 @@ module digital_timer #() (
                         .int_reset_b       (int_reset_b),
                         .clock_digit_in    (digital_clock_in[iter]),
                         .clock_digit_out   (digital_clock_out[iter]),
-                        .prev_overflow_ind (hour_digit_overflow[0]),
+                        .prev_overflow_ind ({hour_digit_overflow[0], min_digit_overflow, sec_digit_overflow}),
                         .overflow_ind      (hour_digit_overflow[1])
                     );
             endcase


### PR DESCRIPTION
Seconds second digit, minutes and hours digits all do not increment correctly as a normal digital timer/clock would
- Fix is to modify the previous overflow indicator to take into account all previous digits' status
- By taking into account all previous digits' status, the subsequent digits will not increment unexpectedly
- Increment will only occur when all previous overflow indicators are 1